### PR TITLE
fix E_WARNING: count() when tag does not exist in cache

### DIFF
--- a/code/services/SimpleCache.php
+++ b/code/services/SimpleCache.php
@@ -349,8 +349,9 @@ class SimpleCache {
 	public function deleteByTag($tag) {
 		$tagKey = $this->tagKey($tag);
 		$keys = $this->get($tagKey);
-        $num = count($keys);
+		$num = 0;
 		if ($keys) {
+			$num = count($keys);
 			foreach ($keys as $key => $dummy) {
 				$this->delete($key);
 			}


### PR DESCRIPTION
Fix the warning raised by calling count on a null object in deleteByTag method.